### PR TITLE
Add an option to forcibly logout users after closing the modal (#41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This plugin displays notices to users.
  * Set a start date and expiry date for a notice
  * Keep displaying a notice until a specific course is completed.
  * Optionally request users to accept a notice, or they will be logged out from LMS.
+ * Force users to be logged out after seeing a notice.
  * Reporting on who accepted / dismissed a notice. 
 
 ## Configuration 
@@ -39,7 +40,8 @@ If the config is enabled (and "notice deletion" is also allowed), when deleting 
 * Enter Content
 * Set up reset interval ('reset every') if required. The notice will be displayed to user again once the specified period elapses.
 * Set up start and end dates if required. Set "Is perpetual" to "Yes" and start/end dates will become available.
-* Requires Acknowledgement. If enabled, the user will need to accept the notice before they can continue to use the LMS site.
+* Requires Acknowledgement: If enabled, the user will need to accept the notice before they can continue to use the LMS site.
+* Forece logout: If enabled, the user will be logged out of the site after closing the notice.
 If the user does not accept the notice, he/she will be logged out of the site.
 * Set up target audience (cohort) 
 

--- a/classes/form/notice_form.php
+++ b/classes/form/notice_form.php
@@ -62,6 +62,11 @@ class notice_form extends \core\form\persistent {
 
         $mform->setDefault('reqack', 0);
 
+        $mform->addElement('selectyesno', 'forcelogout', get_string('notice:forcelogout', 'local_sitenotice'));
+        $mform->addHelpButton('forcelogout', 'notice:forcelogout', 'local_sitenotice');
+
+        $mform->setDefault('forcelogout', 0);
+
         $audience = helper::built_audience_options();
 
         $mform->addElement('select', 'audience', get_string('notice:audience', 'local_sitenotice'), $audience);

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -494,11 +494,6 @@ class helper {
             // Record dismiss action.
             self::create_new_acknowledge_record($noticeid, acknowledgement::ACTION_DISMISSED);
 
-            // Log user out.
-            require_logout();
-            $loginpage = new \moodle_url("/login/index.php");
-            $result['redirecturl'] = $loginpage->out();
-
             // Log dismissed event.
             $params = array(
                 'context' => \context_system::instance(),
@@ -511,6 +506,12 @@ class helper {
 
         // Mark notice as viewed.
         self::add_to_viewed_notices($noticeid, acknowledgement::ACTION_DISMISSED);
+
+        if ((!is_siteadmin() && $notice->get('forcelogout')) || $notice->get('reqack')) {
+            require_logout();
+            $loginpage = new \moodle_url("/login/index.php");
+            $result['redirecturl'] = $loginpage->out();
+        }
 
         $result['status'] = true;
         return $result;
@@ -549,6 +550,14 @@ class helper {
         } else {
             $result['status'] = false;
         }
+
+        $notice = sitenotice::get_record(['id' => $noticeid]);
+        if ($notice && !is_siteadmin() && $notice->get('forcelogout')) {
+            require_logout();
+            $loginpage = new \moodle_url("/login/index.php");
+            $result['redirecturl'] = $loginpage->out();
+        }
+
         return $result;
     }
 

--- a/classes/persistent/sitenotice.php
+++ b/classes/persistent/sitenotice.php
@@ -63,6 +63,11 @@ class sitenotice extends persistent {
                 'null' => NULL_NOT_ALLOWED,
                 'default' => 0,
             ],
+            'forcelogout' => [
+                'type' => PARAM_INT,
+                'null' => NULL_NOT_ALLOWED,
+                'default' => 0,
+            ],
             'timestart' => [
                 'type' => PARAM_INT,
                 'null' => NULL_NOT_ALLOWED,

--- a/classes/table/all_notices.php
+++ b/classes/table/all_notices.php
@@ -67,6 +67,7 @@ class all_notices extends table_sql implements renderable {
             'title' => get_string('notice:title', 'local_sitenotice'),
             'resetinterval' => get_string('notice:resetinterval', 'local_sitenotice'),
             'reqack' => get_string('notice:reqack', 'local_sitenotice'),
+            'forcelogout' => get_string('notice:forcelogout', 'local_sitenotice'),
             'reqcourse' => get_string('notice:reqcourse', 'local_sitenotice'),
             'timestart' => get_string('notice:activefrom', 'local_sitenotice'),
             'timeend' => get_string('notice:expiry', 'local_sitenotice'),
@@ -235,6 +236,16 @@ class all_notices extends table_sql implements renderable {
      */
     protected function col_reqack($row) {
         return helper::format_boolean($row->reqack);
+    }
+
+    /**
+     * The force logout column.
+     *
+     * @param \stdClass $row The row data
+     * @return string
+     */
+    protected function col_forcelogout(\stdClass $row): string {
+        return helper::format_boolean($row->forcelogout);
     }
 
     /**

--- a/db/install.xml
+++ b/db/install.xml
@@ -19,6 +19,7 @@
         <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Timestamp of when the notice was last modified."/>
         <FIELD NAME="timestart" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Time that the notice starts"/>
         <FIELD NAME="timeend" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Time that the notice ends (expires)."/>
+        <FIELD NAME="forcelogout" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Force user to be logged out after viewing the notice: 1 - YES, 0 - NO"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -64,6 +64,17 @@ function xmldb_local_sitenotice_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2022061300, 'local', 'sitenotice');
     }
 
-    return true;
+    if ($oldversion < 2022062000) {
 
+        if (!$dbman->field_exists('local_sitenotice', 'forcelogout')) {
+
+            $table = new xmldb_table('local_sitenotice');
+            $field = new xmldb_field('forcelogout', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '0');
+            $dbman->add_field($table, $field);
+        }
+
+        upgrade_plugin_savepoint(true, 2022062000, 'local', 'sitenotice');
+    }
+
+    return true;
 }

--- a/lang/en/local_sitenotice.php
+++ b/lang/en/local_sitenotice.php
@@ -55,6 +55,8 @@ $string['notice:expiry_help'] = 'The time and date the messages expires and will
 $string['notice:reqack'] = 'Requires acknowledgement';
 $string['notice:reqack_help'] = 'If enabled, the user will need to accept the notice before they can continue to use the LMS site.
 If the user does not accept the notice, he/she will be logged out of the site.';
+$string['notice:forcelogout'] = 'Force logout';
+$string['notice:forcelogout_help'] = 'If enabled, the user will be logged out after closing the notice. This setting does not affect the site administrator. ';
 $string['notice:reqcourse'] = 'Requires course completion';
 $string['notice:reqcourse_help'] = 'If selected, the user will see the notice till the course is completed.';
 $string['notice:disable'] = 'Disable notice';

--- a/tests/behat/behat_local_sitenotice.php
+++ b/tests/behat/behat_local_sitenotice.php
@@ -1,0 +1,67 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Steps definitions related to local_sitenotice.
+ *
+ * @package    local_sitenotice
+ * @copyright  2022 Catalyst IT Australia Pty Ltd
+ * @author     Cameron Ball <cameron@cameron1729.xyz>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+// NOTE: no MOODLE_INTERNAL test here, this file may be required by behat before including /config.php.
+
+require_once(__DIR__ . '/../../../../lib/behat/behat_base.php');
+
+use Behat\Gherkin\Node\TableNode as TableNode;
+
+/**
+ * Site notice step definitions.
+ *
+ * @package    local_sitenotice
+ * @copyright  2022 Catalyst IT Australia Pty Ltd
+ * @author     Cameron Ball <cameron@cameron1729.xyz>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class behat_local_sitenotice extends behat_base {
+
+    /**
+     * Creates new notices.
+     *
+     * @Given the following site notices exist
+     * @param TableNode $noticedata The notices to be created.
+     */
+    public function the_following_site_notices_exist(TableNode $noticedata) {
+        global $DB;
+
+        // Add the discussions to the relevant forum.
+        foreach ($noticedata->getHash() as $noticeinfo) {
+            $now = time();
+            $noticeinfo['audience'] = $noticeinfo['audience'] ?? 0;
+            $noticeinfo['reqack'] = $noticeinfo['reqack'] ?? 0;
+            $noticeinfo['enabled'] = $noticeinfo['enabled'] ?? 1;
+            $noticeinfo['resetinterval'] = $noticeinfo['resetinterval'] ?? 0;
+            $noticeinfo['usermodified'] = $noticeinfo['usermodified'] ?? 2;
+            $noticeinfo['timecreated'] = $noticeinfo['timecreated'] ?? $now;
+            $noticeinfo['timemodified'] = $noticeinfo['timemodified'] ?? $now;
+            $noticeinfo['timestart'] = $noticeinfo['timestart'] ?? 0;
+            $noticeinfo['timeend'] = $noticeinfo['timeend'] ?? 0;
+            $noticeinfo['forcelogout'] = $noticeinfo['forcelogout'] ?? 0;
+            $DB->insert_record('local_sitenotice', $noticeinfo);
+        }
+    }
+}

--- a/tests/behat/force_logout.feature
+++ b/tests/behat/force_logout.feature
@@ -1,0 +1,62 @@
+@local @local_sitenotice
+Feature: Users are forcibly logged out after closing a notice
+  In order to enforce certain policies
+  As a site administrator
+  I need to be able to log people out of the site forcibly
+
+  Background:
+    Given the following "users" exist:
+      | username | firstname | lastname | email                      |
+      | bilbo    | Bilbo     | Baggins  | bilbo@westfarthing.invalid |
+    And I change window size to "large"
+    And I log in as "admin"
+    And I navigate to "Site notice > Settings" in site administration
+    And I click on "Enabled" "checkbox"
+    And I click on "Save changes" "button"
+
+  @javascript
+  Scenario: Users are logged out after closing a regular notice
+    Given the following site notices exist
+      | title         | content                        | forcelogout |
+      | Logout notice | closing this will log you out  | 1           |
+    When I log in as "bilbo"
+    And I am on site homepage
+    Then I should see "closing this will log you out"
+    And I click on "sitenotice-closebtn" "button"
+    Then I should see "Log in"
+    And I log in as "admin"
+    Then I should see "closing this will log you out"
+    And I click on "sitenotice-closebtn" "button"
+    Then I should see "You are logged in as Admin User"
+
+  @javascript
+  Scenario: Users are logged out after dismissing an acknowledgement notice
+    Given the following site notices exist
+      | title         | content                        | forcelogout | reqack |
+      | Logout notice | closing this will log you out  | 1           | 1      |
+    When I log in as "bilbo"
+    And I am on site homepage
+    Then I should see "closing this will log you out"
+    And I click on "sitenotice-closebtn" "button"
+    Then I should see "Log in"
+    And I log in as "admin"
+    Then I should see "closing this will log you out"
+    And I click on "sitenotice-closebtn" "button"
+    Then I should see "Log in"
+
+  @javascript
+  Scenario: Users are logged out after accepting an acknowledgement notice
+    Given the following site notices exist
+      | title         | content                        | forcelogout | reqack |
+      | Logout notice | closing this will log you out  | 1           | 1      |
+    When I log in as "bilbo"
+    And I am on site homepage
+    Then I should see "closing this will log you out"
+    And I click on "sitenotice-modal-ackcheckbox" "checkbox"
+    And I click on "sitenotice-acceptbtn" "button"
+    Then I should see "Log in"
+    And I log in as "admin"
+    Then I should see "closing this will log you out"
+    And I click on "sitenotice-modal-ackcheckbox" "checkbox"
+    And I click on "sitenotice-acceptbtn" "button"
+    Then I should see "You are logged in as Admin User"

--- a/tests/behat/require_acknowledge.feature
+++ b/tests/behat/require_acknowledge.feature
@@ -1,0 +1,38 @@
+@local @local_sitenotice
+Feature: Users are forcibly logged out after closing a notice which requires acknowledgement
+  In order to enforce certain policies
+  As a site administrator
+  I need to be able to log people out of the site forcibly when they do not acknowledge a notice
+
+  Background:
+    Given the following "users" exist:
+      | username | firstname | lastname | email                      |
+      | bilbo    | Bilbo     | Baggins  | bilbo@westfarthing.invalid |
+    And I change window size to "large"
+    And I log in as "admin"
+    And I navigate to "Site notice > Settings" in site administration
+    And I click on "Enabled" "checkbox"
+    And I click on "Save changes" "button"
+
+  @javascript
+  Scenario: Users are logged out after closing a notice without acknowledging it
+    Given the following site notices exist
+      | title         | content                                  | reqack |
+      | Logout notice | not acknowledging this will log you out  | 1      |
+    When I log in as "bilbo"
+    And I am on site homepage
+    Then I should see "not acknowledging this will log you out"
+    And I click on "sitenotice-closebtn" "button"
+    Then I should see "Log in"
+
+  @javascript
+  Scenario: Users are not logged out after acknowledging a notice and closing it
+    Given the following site notices exist
+      | title         | content                                  | reqack |
+      | Logout notice | not acknowledging this will log you out  | 1      |
+    When I log in as "bilbo"
+    And I am on site homepage
+    Then I should see "not acknowledging this will log you out"
+    And I click on "sitenotice-modal-ackcheckbox" "checkbox"
+    And I click on "sitenotice-acceptbtn" "button"
+    Then I should see "You are logged in as Bilbo Baggins"

--- a/version.php
+++ b/version.php
@@ -26,8 +26,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_sitenotice'; // Full name of the plugin (used for diagnostics).
-$plugin->version = 2022061300;           // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release = 2022061300;
+$plugin->version = 2022062000;           // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release = 2022062000;
 $plugin->requires = 2018051709;          // Requires this Moodle version.
 $plugin->supported = [39, 401];  // Available as of Moodle 3.9.0 or later.
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
This patch adds a new option, "Force logout", when enabled users will be logged out as soon as they close the modal.