### PR TITLE
Modify helper class to use instantiated notices (#47)

### DIFF
--- a/classes/external.php
+++ b/classes/external.php
@@ -41,8 +41,10 @@ class local_sitenotice_external extends external_api {
     public static function dismiss_notice($noticeid) {
         $params = self::validate_parameters(self::dismiss_notice_parameters(),
             array('noticeid' => $noticeid));
-        $notice = sitenotice::get_record(['id' => $params['noticeid']]);
-        return helper::dismiss_notice($notice);
+
+        if ($notice = sitenotice::get_record(['id' => $params['noticeid']])) {
+            return helper::dismiss_notice($notice);
+        }
     }
 
     public static function dismiss_notice_returns() {
@@ -65,8 +67,10 @@ class local_sitenotice_external extends external_api {
     public static function acknowledge_notice($noticeid) {
         $params = self::validate_parameters(self::acknowledge_notice_parameters(),
             array('noticeid' => $noticeid));
-        $notice = sitenotice::get_record(['id' => $params['noticeid']]);
-        return helper::acknowledge_notice($notice);
+
+        if ($notice = sitenotice::get_record(['id' => $params['noticeid']])) {
+            return helper::acknowledge_notice($notice);
+        }
     }
 
     public static function acknowledge_notice_returns() {

--- a/classes/external.php
+++ b/classes/external.php
@@ -26,6 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once("$CFG->libdir/externallib.php");
 use local_sitenotice\helper;
+use local_sitenotice\persistent\sitenotice;
 
 class local_sitenotice_external extends external_api {
 
@@ -40,7 +41,8 @@ class local_sitenotice_external extends external_api {
     public static function dismiss_notice($noticeid) {
         $params = self::validate_parameters(self::dismiss_notice_parameters(),
             array('noticeid' => $noticeid));
-         return helper::dismiss_notice($params['noticeid']);
+        $notice = sitenotice::get_record(['id' => $params['noticeid']]);
+        return helper::dismiss_notice($notice);
     }
 
     public static function dismiss_notice_returns() {
@@ -63,7 +65,8 @@ class local_sitenotice_external extends external_api {
     public static function acknowledge_notice($noticeid) {
         $params = self::validate_parameters(self::acknowledge_notice_parameters(),
             array('noticeid' => $noticeid));
-        return helper::acknowledge_notice($params['noticeid']);
+        $notice = sitenotice::get_record(['id' => $params['noticeid']]);
+        return helper::acknowledge_notice($notice);
     }
 
     public static function acknowledge_notice_returns() {
@@ -104,7 +107,15 @@ class local_sitenotice_external extends external_api {
     public static function get_notices() {
         $result = array();
         $result['status'] = true;
-        $result['notices'] = json_encode(helper::retrieve_user_notices());
+        $result['notices'] = json_encode(
+            array_map(
+                function(sitenotice $notice): \stdClass {
+                    return $notice->to_record();
+                },
+                helper::retrieve_user_notices()
+            )
+        );
+
         return $result;
     }
 

--- a/classes/persistent/sitenotice.php
+++ b/classes/persistent/sitenotice.php
@@ -137,47 +137,6 @@ class sitenotice extends persistent {
     }
 
     /**
-     * Enable a notice.
-     * @param $noticeid notice id
-     * @return sitenotice
-     * @throws \coding_exception
-     * @throws \core\invalid_persistent_exception
-     */
-    public static function enable($noticeid) {
-        $persistent = new sitenotice($noticeid);
-        $persistent->set('enabled', 1);
-        $persistent->update();
-        return $persistent;
-    }
-
-    /**
-     * Disable a notice.
-     * @param $noticeid notice id
-     * @return sitenotice
-     * @throws \coding_exception
-     * @throws \core\invalid_persistent_exception
-     */
-    public static function disable($noticeid) {
-        $persistent = new sitenotice($noticeid);
-        $persistent->set('enabled', 0);
-        $persistent->update();
-        return $persistent;
-    }
-
-    /**
-     * Reset a notice.
-     * @param $noticeid notice id
-     * @return sitenotice
-     * @throws \coding_exception
-     * @throws \core\invalid_persistent_exception
-     */
-    public static function reset($noticeid) {
-        $persistent = new sitenotice($noticeid);
-        $persistent->update();
-        return $persistent;
-    }
-
-    /**
      * Get enabled notices.
      *
      * @return \stdClass[]
@@ -185,13 +144,7 @@ class sitenotice extends persistent {
     public static function get_enabled_notices(): array {
         if (!$result = self::get_enabled_notices_cache()->get('records')) {
             $select = "enabled = ? AND ((timeend = 0 AND timestart = 0) OR (timeend <> 0 AND timestart <> 0 AND ? < timeend))";
-            $persistents = self::get_records_select($select, [1, time()], 'id');
-            $result = [];
-            foreach ($persistents as $persistent) {
-                $record = $persistent->to_record();
-                $result[$record->id] = $record;
-            }
-
+            $result = self::get_records_select($select, [1, time()], 'id');
             self::get_enabled_notices_cache()->set('records', $result);
         }
 
@@ -203,14 +156,8 @@ class sitenotice extends persistent {
      *
      * @return \stdClass[]
      */
-    public static function get_all_notice_records(): array {
-        $persistents = self::get_records([], 'timemodified', 'DESC');
-        $result = [];
-        foreach ($persistents as $persistent) {
-            $record = $persistent->to_record();
-            $result[$record->id] = $record;
-        }
-        return $result;
+    public static function get_all_notices(): array {
+        return self::get_records([], 'timemodified', 'DESC');
     }
 
     /**

--- a/classes/table/acknowledged_notice.php
+++ b/classes/table/acknowledged_notice.php
@@ -26,10 +26,11 @@ namespace local_sitenotice\table;
 defined('MOODLE_INTERNAL') || die();
 require_once($CFG->libdir . '/tablelib.php');
 
-use local_sitenotice\persistent\acknowledgement;
 use table_sql;
 use renderable;
 use local_sitenotice\helper;
+use local_sitenotice\persistent\acknowledgement;
+use local_sitenotice\persistent\linkhistory;
 
 class acknowledged_notice extends table_sql implements renderable {
     // Notice id.
@@ -242,7 +243,7 @@ class acknowledged_notice extends table_sql implements renderable {
             return '';
         }
         $hlinkcount = '';
-        $linkcounts = helper::count_clicked_notice_links($row->userid, $row->noticeid);
+        $linkcounts = linkhistory::count_clicked_links($row->userid, $row->noticeid);
         foreach ($linkcounts as $count) {
             $hlinkcount .= "<a href=\"{$count->link}\">{$count->text}</a>: $count->count <br/>";
         }
@@ -263,7 +264,7 @@ class acknowledged_notice extends table_sql implements renderable {
             if ($this->previoususer == $row->userid) {
                 return '';
             }
-            $linkcounts = helper::count_clicked_notice_links($row->userid, $row->noticeid, $column);
+            $linkcounts = linkhistory::count_clicked_links($row->userid, $row->noticeid, $column);
             if (isset($linkcounts[$column])) {
                 return $linkcounts[$column]->count;
             } else {

--- a/tests/helper_test.php
+++ b/tests/helper_test.php
@@ -59,18 +59,18 @@ class helper_test extends \advanced_testcase {
         $formdata->content = 'Moodle <iframe width="1280" height="720" src="https://www.youtube.com/embed/3ORsUGVNxGs"></iframe>';
         helper::create_new_notice($formdata);
 
-        $allnotices = helper::retrieve_all_notices();
+        $allnotices = sitenotice::get_all_notices();
         $actual = reset($allnotices);
-        $this->assertStringContainsString($formdata->content, $actual->content);
+        $this->assertStringContainsString($formdata->content, $actual->get('content'));
 
         $formdata->title = 'Updated notice';
         $formdata->content = 'Updated  <iframe width="1280" height="720" src="https://www.youtube.com/embed/wop3FMhoLGs"></iframe>';
-        $sitenotice = sitenotice::get_record(['id' => $actual->id]);
+        $sitenotice = sitenotice::get_record(['id' => $actual->get('id')]);
         helper::update_notice($sitenotice, $formdata);
 
-        $allnotices = helper::retrieve_all_notices();
+        $allnotices = sitenotice::get_all_notices();
         $actual = reset($allnotices);
-        $this->assertStringContainsString($formdata->content, $actual->content);
+        $this->assertStringContainsString($formdata->content, $actual->get('content'));
     }
 
 }

--- a/version.php
+++ b/version.php
@@ -26,8 +26,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_sitenotice'; // Full name of the plugin (used for diagnostics).
-$plugin->version = 2022062000;           // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release = 2022062000;
+$plugin->version = 2022062400;           // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release = 2022062400;
 $plugin->requires = 2018051709;          // Requires this Moodle version.
 $plugin->supported = [39, 401];  // Available as of Moodle 3.9.0 or later.
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
* Helper class methods now require instantiated site notices (instead of an ID which is then loaded)
* External functions load the class once then pass to helper methods
* General phpdoc improvements and type annotations
* Removed some unnecessary methods from the helper class

I did some basic profiling and was able to verify that when acknowledging a notice the total number of queries dropped by 2.

Fixes #47 