### PR TITLE
issue #79 replace mb_convert_encoding function

### DIFF
--- a/classes/form/notice_form.php
+++ b/classes/form/notice_form.php
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-
 namespace local_sitenotice\form;
 
 use local_sitenotice\helper;
@@ -41,7 +40,7 @@ class notice_form extends \core\form\persistent {
     /**
      * Form definition.
      */
-    public function definition () {
+    public function definition() {
         $mform =& $this->_form;
 
         $mform->addElement('hidden', 'id', 0);

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -143,7 +143,7 @@ class helper {
         // Extract hyperlinks from the content of the notice, which is then used for link clicked tracking.
         $dom = new \DOMDocument();
         $content = format_text($content, FORMAT_HTML, ['noclean' => true]);
-        $content = mb_convert_encoding($content, 'HTML-ENTITIES', 'UTF-8' );
+        $content = self::html_entities_utf8($content);
         $dom->loadHTML($content);
         // Current links in the notice.
         $currentlinks = noticelink::get_notice_link_records($notice->get('id'));
@@ -172,6 +172,42 @@ class helper {
         // New content of the notice (included link ids).
         $newcontent = $dom->saveHTML();
         return $newcontent;
+    }
+
+    /**
+     * Converts special multibyte UTF-8 characters in HTML content to HTML entities.
+     *
+     * - Latin-1 accented characters (é, à, ü, etc.) are converted to named entities (&eacute;, &agrave;, &uuml;, etc.).
+     * - Other non-ASCII characters, such as emojis, are converted to numeric entities (😃 → &#128515;).
+     * - ASCII characters (a-z, 0-9, punctuation) are left unchanged.
+     * - Existing HTML tags and already-encoded entities (like &amp;) are preserved.
+     *
+     * This function is intended as a lightweight replacement for the deprecated
+     * mb_convert_encoding(..., 'HTML-ENTITIES', 'UTF-8'), focusing only on
+     * converting visible characters without affecting HTML structure.
+     *
+     * @param string $html The HTML string to convert.
+     * @return string The HTML string with special characters converted to entities.
+     */
+    private static function html_entities_utf8(string $html): string {
+        // Map only Latin-1 characters that have named entities.
+        static $map = null;
+        if ($map === null) {
+            $map = get_html_translation_table(HTML_ENTITIES, ENT_NOQUOTES | ENT_HTML5, 'UTF-8');
+        }
+
+        return preg_replace_callback(
+            '/[\xC2-\xF4][\x80-\xBF]+/', // match multibyte UTF-8 characters
+            function ($m) use ($map) {
+                $char = $m[0];
+                if (isset($map[$char])) {
+                    return $map[$char]; // é → &eacute;
+                }
+                $codepoint = \IntlChar::ord($char);
+                return '&#' . $codepoint . ';'; // emoji → &#128515;
+            },
+            $html
+        );
     }
 
     /**

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -143,7 +143,7 @@ class helper {
         // Extract hyperlinks from the content of the notice, which is then used for link clicked tracking.
         $dom = new \DOMDocument();
         $content = format_text($content, FORMAT_HTML, ['noclean' => true]);
-        $content = self::html_entities_utf8($content);
+        $content = mb_encode_numericentity($content, [0x80, 0x10FFFF, 0, ~0], 'UTF-8');
         $dom->loadHTML($content);
         // Current links in the notice.
         $currentlinks = noticelink::get_notice_link_records($notice->get('id'));
@@ -172,42 +172,6 @@ class helper {
         // New content of the notice (included link ids).
         $newcontent = $dom->saveHTML();
         return $newcontent;
-    }
-
-    /**
-     * Converts special multibyte UTF-8 characters in HTML content to HTML entities.
-     *
-     * - Latin-1 accented characters (é, à, ü, etc.) are converted to named entities (&eacute;, &agrave;, &uuml;, etc.).
-     * - Other non-ASCII characters, such as emojis, are converted to numeric entities (😃 → &#128515;).
-     * - ASCII characters (a-z, 0-9, punctuation) are left unchanged.
-     * - Existing HTML tags and already-encoded entities (like &amp;) are preserved.
-     *
-     * This function is intended as a lightweight replacement for the deprecated
-     * mb_convert_encoding(..., 'HTML-ENTITIES', 'UTF-8'), focusing only on
-     * converting visible characters without affecting HTML structure.
-     *
-     * @param string $html The HTML string to convert.
-     * @return string The HTML string with special characters converted to entities.
-     */
-    private static function html_entities_utf8(string $html): string {
-        // Map only Latin-1 characters that have named entities.
-        static $map = null;
-        if ($map === null) {
-            $map = get_html_translation_table(HTML_ENTITIES, ENT_NOQUOTES | ENT_HTML5, 'UTF-8');
-        }
-
-        return preg_replace_callback(
-            '/[\xC2-\xF4][\x80-\xBF]+/', // match multibyte UTF-8 characters
-            function ($m) use ($map) {
-                $char = $m[0];
-                if (isset($map[$char])) {
-                    return $map[$char]; // é → &eacute;
-                }
-                $codepoint = \IntlChar::ord($char);
-                return '&#' . $codepoint . ';'; // emoji → &#128515;
-            },
-            $html
-        );
     }
 
     /**

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -16,11 +16,11 @@
 
 namespace local_sitenotice;
 
-use \local_sitenotice\persistent\sitenotice;
-use \local_sitenotice\persistent\noticelink;
-use \local_sitenotice\persistent\linkhistory;
-use \local_sitenotice\persistent\acknowledgement;
-use \local_sitenotice\persistent\noticeview;
+use local_sitenotice\persistent\sitenotice;
+use local_sitenotice\persistent\noticelink;
+use local_sitenotice\persistent\linkhistory;
+use local_sitenotice\persistent\acknowledgement;
+use local_sitenotice\persistent\noticeview;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -711,7 +711,7 @@ class helper {
             'maxfiles' => -1, // Unlimited files.
             'context' => \context_system::instance(),
             'trusttext' => true,
-            'class' => 'noticecontent'
+            'class' => 'noticecontent',
         ];
     }
 }

--- a/classes/persistent/sitenotice.php
+++ b/classes/persistent/sitenotice.php
@@ -48,7 +48,7 @@ class sitenotice extends persistent {
             ],
             'contentformat' => array(
                 'type' => PARAM_INT,
-                'default' => FORMAT_HTML
+                'default' => FORMAT_HTML,
             ),
             'cohorts' => [
                 'type' => PARAM_RAW,
@@ -73,12 +73,12 @@ class sitenotice extends persistent {
             'timestart' => [
                 'type' => PARAM_INT,
                 'null' => NULL_NOT_ALLOWED,
-                'default' => 0
+                'default' => 0,
             ],
             'timeend' => [
                 'type' => PARAM_INT,
                 'null' => NULL_NOT_ALLOWED,
-                'default' => 0
+                'default' => 0,
             ],
             'enabled' => [
                 'type' => PARAM_INT,

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -52,7 +52,7 @@ class provider implements
 
         $params = [
             'contextuser'   => CONTEXT_USER,
-            'userid'        => $userid
+            'userid'        => $userid,
         ];
 
         $contextlist->add_from_sql($sql, $params);

--- a/classes/report_filter.php
+++ b/classes/report_filter.php
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-
 namespace local_sitenotice;
 
 use local_sitenotice\form\active_filter_form;
@@ -47,7 +46,7 @@ class report_filter {
 
     /**
      * Base URL.
-     * @var
+     * @var string
      */
     private $baseurl;
 

--- a/classes/table/all_notices.php
+++ b/classes/table/all_notices.php
@@ -35,6 +35,8 @@ require_once($CFG->libdir . '/tablelib.php');
  */
 class all_notices extends table_sql implements renderable {
 
+    protected $page;
+
     /**
      * all_notices constructor.
      *

--- a/classes/table/all_notices.php
+++ b/classes/table/all_notices.php
@@ -35,6 +35,7 @@ require_once($CFG->libdir . '/tablelib.php');
  */
 class all_notices extends table_sql implements renderable {
 
+    /** @var int */
     protected $page;
 
     /**

--- a/classes/table/dismissed_notice.php
+++ b/classes/table/dismissed_notice.php
@@ -91,7 +91,7 @@ class dismissed_notice extends table_sql implements renderable {
             'username' => get_string('username'),
             'firstname' => get_string('firstname'),
             'lastname' => get_string('lastname'),
-            'idnumber' => get_string('idnumber')
+            'idnumber' => get_string('idnumber'),
         );
 
         if ($this->is_downloading()) {

--- a/db/access.php
+++ b/db/access.php
@@ -29,7 +29,7 @@ $capabilities = array(
 
     'local/sitenotice:manage' => array(
         'captype' => 'write',
-        'contextlevel' => CONTEXT_SYSTEM
+        'contextlevel' => CONTEXT_SYSTEM,
     ),
 
 );

--- a/db/caches.php
+++ b/db/caches.php
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-
 /**
  * Cache details.
  *
@@ -28,9 +27,9 @@ defined('MOODLE_INTERNAL') || die();
 
 $definitions = [
     'enabled_notices' => [
-        'mode' => cache_store::MODE_APPLICATION
+        'mode' => cache_store::MODE_APPLICATION,
     ],
     'notice_view' => [
-        'mode' => cache_store::MODE_APPLICATION
-    ]
+        'mode' => cache_store::MODE_APPLICATION,
+    ],
 ];

--- a/editnotice.php
+++ b/editnotice.php
@@ -47,7 +47,7 @@ $PAGE->requires->js_call_amd('local_sitenotice/notice_form', 'init', array());
 $sitenotice = sitenotice::get_record(['id' => $noticeid]);
 $customdata = [
     'persistent' => $sitenotice,
-    'id' => $noticeid
+    'id' => $noticeid,
 ];
 $mform = new notice_form($thispage, $customdata);
 

--- a/renderer.php
+++ b/renderer.php
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-
 defined('MOODLE_INTERNAL') || die();
 
 use local_sitenotice\table\dismissed_notice;;

--- a/report/acknowledged_report.php
+++ b/report/acknowledged_report.php
@@ -21,6 +21,7 @@
  * @copyright  Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+
 require_once(__DIR__.'/../../../config.php');
 
 use local_sitenotice\helper;

--- a/report/dismissed_report.php
+++ b/report/dismissed_report.php
@@ -21,6 +21,7 @@
  * @copyright  Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+
 require_once(__DIR__.'/../../../config.php');
 
 use local_sitenotice\helper;

--- a/tests/helper_test.php
+++ b/tests/helper_test.php
@@ -73,6 +73,15 @@ class helper_test extends \advanced_testcase {
         $allnotices = sitenotice::get_all_notices();
         $actual = reset($allnotices);
         $this->assertStringContainsString($formdata->content, $actual->get('content'));
+
+        // Test for some special UTF-8 characters. HTML reserved characters must be converted in the form.
+        $formdata->content = '<p>Héllo 😃 world &amp; café</p>';
+        $expected = '<p>H&eacute;llo &#128515; world &amp; caf&eacute;</p>';
+        helper::update_notice($sitenotice, $formdata);
+
+        $allnotices = sitenotice::get_all_notices();
+        $actual = reset($allnotices);
+        $this->assertStringContainsString($expected, $actual->get('content'));
     }
 
     /**

--- a/tests/sitenotice_test.php
+++ b/tests/sitenotice_test.php
@@ -34,7 +34,7 @@ class sitenotice_test extends \advanced_testcase {
      * Initial set up.
      */
     protected function setUp(): void {
-        parent::setup();
+        parent::setUp();
         $this->resetAfterTest(true);
     }
 
@@ -445,7 +445,7 @@ class sitenotice_test extends \advanced_testcase {
      *
      * @return array
      */
-    public function generic_provider() {
+    public function generic_provider(): array {
         return [
             'formdata' => [
                 [
@@ -470,9 +470,9 @@ class sitenotice_test extends \advanced_testcase {
                         'content' => 'Cohort Notice 2 <a href="www.example7.com">Link 7</a> <a href="www.example8.com">Link 8</a>',
                         'cohorts' => '',
                         'perpetual' => 1,
-                    ]
-                ]
-            ]
+                    ],
+                ],
+            ],
         ];
     }
 
@@ -498,8 +498,8 @@ class sitenotice_test extends \advanced_testcase {
                     'titles' => ['Notice 1'],
                     'linkcounts' => [2],
                     'linktexts' => [['Link 1', 'Link 2']],
-                    'linkurls' => [['www.example1.com', 'www.example2.com']]
-                ]
+                    'linkurls' => [['www.example1.com', 'www.example2.com']],
+                ],
             ],
             'two basic notices with deletion not allowed' => [
                 'formdata' => [
@@ -521,8 +521,8 @@ class sitenotice_test extends \advanced_testcase {
                     'titles' => ['Notice 1', 'Notice 2'],
                     'linkcounts' => [2, 2],
                     'linktexts' => [['Link 1', 'Link 2'], ['Link 1', 'Link 4']],
-                    'linkurls' => [['www.example1.com', 'www.example2.com'], ['www.example1.com', 'www.example2.com']]
-                ]
+                    'linkurls' => [['www.example1.com', 'www.example2.com'], ['www.example1.com', 'www.example2.com']],
+                ],
             ],
             'two basic notices and one notice with expiry in the future' => [
                 'formdata' => [
@@ -541,7 +541,7 @@ class sitenotice_test extends \advanced_testcase {
                         'content' => 'Notice 3 <a href="www.example1.com">Link 1</a> <a href="www.example2.com">Link 4</a>',
                         'perpetual' => 0,
                         'timestart' => time() + HOURSECS,
-                        'timeend' => time() + DAYSECS
+                        'timeend' => time() + DAYSECS,
                     ],
                 ],
                 'allowdeletion' => false,
@@ -551,8 +551,8 @@ class sitenotice_test extends \advanced_testcase {
                     'titles' => ['Notice 1', 'Notice 2', 'Notice 3'],
                     'linkcounts' => [2, 2, 2],
                     'linktexts' => [['Link 1', 'Link 2'], ['Link 1', 'Link 4'], ['Link 1', 'Link 4']],
-                    'linkurls' => [['www.example1.com', 'www.example2.com'], ['www.example1.com', 'www.example2.com'], ['www.example1.com', 'www.example2.com']]
-                ]
+                    'linkurls' => [['www.example1.com', 'www.example2.com'], ['www.example1.com', 'www.example2.com'], ['www.example1.com', 'www.example2.com']],
+                ],
             ],
             'two basic notices and one notice with expiry in the past' => [
                 'formdata' => [
@@ -571,7 +571,7 @@ class sitenotice_test extends \advanced_testcase {
                         'content' => 'Notice 3 <a href="www.example1.com">Link 1</a> <a href="www.example2.com">Link 4</a>',
                         'perpetual' => 0,
                         'timestart' => time() - DAYSECS,
-                        'timeend' => time() - HOURSECS
+                        'timeend' => time() - HOURSECS,
                     ],
                 ],
                 'allowdeletion' => false,
@@ -581,8 +581,8 @@ class sitenotice_test extends \advanced_testcase {
                     'titles' => ['Notice 1', 'Notice 2'],
                     'linkcounts' => [2, 2],
                     'linktexts' => [['Link 1', 'Link 2'], ['Link 1', 'Link 4']],
-                    'linkurls' => [['www.example1.com', 'www.example2.com'], ['www.example1.com', 'www.example2.com']]
-                ]
+                    'linkurls' => [['www.example1.com', 'www.example2.com'], ['www.example1.com', 'www.example2.com']],
+                ],
             ],
             'one basic notice with deletion allowed and cleanup disabled' => [
                 'formdata' => [
@@ -599,8 +599,8 @@ class sitenotice_test extends \advanced_testcase {
                     'titles' => ['Notice 1'],
                     'linkcounts' => [2],
                     'linktexts' => [['Link 1', 'Link 2']],
-                    'linkurls' => [['www.example1.com', 'www.example2.com']]
-                ]
+                    'linkurls' => [['www.example1.com', 'www.example2.com']],
+                ],
             ],
             'two basic notices with deletion allowed and cleanup disabled' => [
                 'formdata' => [
@@ -622,8 +622,8 @@ class sitenotice_test extends \advanced_testcase {
                     'titles' => ['Notice 1', 'Notice 2'],
                     'linkcounts' => [2, 2],
                     'linktexts' => [['Link 1', 'Link 2'], ['Link 1', 'Link 4']],
-                    'linkurls' => [['www.example1.com', 'www.example2.com'], ['www.example1.com', 'www.example2.com']]
-                ]
+                    'linkurls' => [['www.example1.com', 'www.example2.com'], ['www.example1.com', 'www.example2.com']],
+                ],
             ],
             'one basic notice with deletion allowed and cleanup enabled' => [
                 'formdata' => [
@@ -640,8 +640,8 @@ class sitenotice_test extends \advanced_testcase {
                     'titles' => ['Notice 1'],
                     'linkcounts' => [2],
                     'linktexts' => [['Link 1', 'Link 2']],
-                    'linkurls' => [['www.example1.com', 'www.example2.com']]
-                ]
+                    'linkurls' => [['www.example1.com', 'www.example2.com']],
+                ],
             ],
             'two basic notices with deletion allowed and cleanup enabled' => [
                 'formdata' => [
@@ -663,9 +663,9 @@ class sitenotice_test extends \advanced_testcase {
                     'titles' => ['Notice 1', 'Notice 2'],
                     'linkcounts' => [2, 2],
                     'linktexts' => [['Link 1', 'Link 2'], ['Link 1', 'Link 4']],
-                    'linkurls' => [['www.example1.com', 'www.example2.com'], ['www.example1.com', 'www.example2.com']]
-                ]
-            ]
+                    'linkurls' => [['www.example1.com', 'www.example2.com'], ['www.example1.com', 'www.example2.com']],
+                ],
+            ],
         ];
     }
 }


### PR DESCRIPTION
Fix issue #79 

A new test case is added in `test_can_have_html_in_notice_content` and it worked both old `mb_convert_encoding($content, 'HTML-ENTITIES', 'UTF-8' );` and `self::html_entities_utf8($content);`
